### PR TITLE
Feature/swagger setting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,9 +29,15 @@ dependencies {
 	// mongodb
 	implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
 
+	//jwt
 	implementation("io.jsonwebtoken:jjwt-api:0.11.2")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
+
+	//swagger
+	implementation ("io.springfox:springfox-boot-starter:3.0.0")
+
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 
 }

--- a/src/main/kotlin/com/bside/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/bside/config/SecurityConfig.kt
@@ -46,10 +46,7 @@ class SecurityConfig(
         return source
     }
 
-    override fun configure(web: WebSecurity?) {
-        web!!.ignoring()
-            .antMatchers("/resource")
-    }
+
 
     override fun configure(http: HttpSecurity?) {
         //csrf 설정
@@ -68,6 +65,11 @@ class SecurityConfig(
             .and()
             .authorizeRequests()
             .antMatchers("/auth/**").permitAll()
+            .antMatchers("/v3/api-docs",
+                "/configuration/ui",
+                "/swagger-resources/**",
+                "/configuration/security",
+                "/swagger-ui/**").permitAll()
             .antMatchers("/admin/**").hasAnyAuthority(Authority.ROLE_ADMIN.name)
             .anyRequest().authenticated()   // 나머지 API 는 전부 인증 필요
             //JwtConfig 등록

--- a/src/main/kotlin/com/bside/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/bside/config/SwaggerConfig.kt
@@ -1,0 +1,59 @@
+package com.bside.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import springfox.documentation.builders.ApiInfoBuilder
+import springfox.documentation.builders.PathSelectors
+import springfox.documentation.builders.RequestHandlerSelectors
+import springfox.documentation.service.*
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.service.contexts.SecurityContext
+import springfox.documentation.spring.web.plugins.Docket
+import java.util.*
+
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun api(): Docket? {
+        //Docket: Swagger 설정의 핵심이 되는 Bean
+        return Docket(DocumentationType.OAS_30)
+            .securityContexts(listOf(securityContext()))
+            .securitySchemes(listOf(apiKey()) as List<SecurityScheme>?)
+            .select()
+            .apis(RequestHandlerSelectors.basePackage("com.bside.controller")) // controller package 지정
+            .paths(PathSelectors.any())
+            .build()
+            .apiInfo(apiInfo()) //:Swagger UI 로 노출할 정보
+    }
+
+    // api 정보 등록
+    private fun apiInfo(): ApiInfo? {
+        return ApiInfoBuilder()
+            .title("Bside 11 Swagger")
+            .description("Bside 11 backend Swagger")
+            .version("1.0")
+            .build()
+    }
+
+    //인증하는 방식 설정
+    private fun securityContext(): SecurityContext? {
+        return SecurityContext
+            .builder()
+            .securityReferences(defaultAuth()).forPaths(PathSelectors.any()).build();
+    }
+
+    private fun defaultAuth(): List<SecurityReference?>? {
+        val authorizationScope = AuthorizationScope("global", "accessEverything")
+        val authorizationScopes = arrayOfNulls<AuthorizationScope>(1)
+        authorizationScopes[0] = authorizationScope
+        return Arrays.asList(SecurityReference("Authorization", authorizationScopes))
+    }
+
+    //api key 설정
+    private fun apiKey(): ApiKey? {
+        return ApiKey("Authorization", "Authorization", "header")
+    }
+
+}

--- a/src/main/resources/application-local-example.yml
+++ b/src/main/resources/application-local-example.yml
@@ -7,5 +7,9 @@
 #    mongodb:
 #      url:
 #
+#
+#  mvc:
+#    pathmatch:
+#      matching-strategy: ant_path_matcher
 #jwt:
 #  secret:


### PR DESCRIPTION
#13 Swagger 3.0 추가

## 접속
 * 접속 url : http://localhost:8080/swagger-ui/index.html

## application.yml 추가 사항
```
mvc:
    pathmatch:
       matching-strategy: ant_path_matcher
```
Spring boot 2.6버전 이후에 spring.mvc.pathmatch.matching-strategy 값이 ant_apth_matcher에서 path_pattern_parser로 변경되면서 몇몇 라이브러리(swagger포함)에 오류가 발생할 수 있다고 합니다.  

application-local-example.yml에도 추가하였으니 참고 부탁드립니다.🙏


## Swagger 테스트 내용 및 사용 설명
* 로그인 테스트
<img width="1306" alt="스크린샷 2022-07-16 오후 4 29 06" src="https://user-images.githubusercontent.com/64948881/179345618-36762fb3-477c-4ea7-8545-3bfb4c0f2950.png">
<img width="1295" alt="스크린샷 2022-07-16 오후 4 29 21" src="https://user-images.githubusercontent.com/64948881/179345639-c28272f8-2f82-427c-87ad-ccceb0bbbdb1.png">
로그인 정상 응답 확인

</br></br></br>

* Header Authorization 설정
<img width="1358" alt="스크린샷 2022-07-16 오후 4 48 03" src="https://user-images.githubusercontent.com/64948881/179345865-36252eae-66d1-4c7f-896b-123db3f7a0cb.png">
<img width="713" alt="스크린샷 2022-07-16 오후 5 09 18" src="https://user-images.githubusercontent.com/64948881/179346566-ad808b1f-8235-4f73-87a7-12b71cfa3424.png">



1. 상단의 Authorize 버튼 클릭
2. Login Response Access_token Bearer 붙인 뒤 설정 ex) Bearer {Access_token}


</br></br></br>

* MemberController 테스트
<img width="1440" alt="스크린샷 2022-07-16 오후 4 29 54" src="https://user-images.githubusercontent.com/64948881/179346041-a00cb9cf-c11d-4e25-81d4-a56f25c75fe3.png">

<img width="1309" alt="스크린샷 2022-07-16 오후 4 30 17" src="https://user-images.githubusercontent.com/64948881/179346559-72b2eaf4-66ad-433a-9558-8081b6045c6f.png">


</br></br></br>


**Swagger 사용은 Wiki에도 따로 정리해 놓겠습니다.**

