### PR TITLE
공통 응답객체 및 전역에러 처리 추가

### DIFF
--- a/src/main/kotlin/com/bside/common/dto/ApiResponseDto.kt
+++ b/src/main/kotlin/com/bside/common/dto/ApiResponseDto.kt
@@ -1,0 +1,13 @@
+package com.bside.common.dto
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+
+class ApiResponseDto {
+    companion object {
+        fun <T> ok(data: T): ResponseEntity<T> = ResponseEntity.ok().body(data)
+        fun <T> created(data: T): ResponseEntity<T> = ResponseEntity.status(HttpStatus.CREATED).body(data)
+    }
+}
+
+

--- a/src/main/kotlin/com/bside/common/type/ErrorMessage.kt
+++ b/src/main/kotlin/com/bside/common/type/ErrorMessage.kt
@@ -1,0 +1,8 @@
+package com.bside.common.type
+
+
+enum class ErrorMessage(val reason: String = "") {
+    INTERNAL_SERVER_ERROR,
+    USER_ALREADY_EXIST("이미 가입되어 있는 유저입니다."),
+    TEST_ERROR_Message_("reason why error occured::optional")
+}

--- a/src/main/kotlin/com/bside/common/type/ErrorMessage.kt
+++ b/src/main/kotlin/com/bside/common/type/ErrorMessage.kt
@@ -4,5 +4,5 @@ package com.bside.common.type
 enum class ErrorMessage(val reason: String = "") {
     INTERNAL_SERVER_ERROR,
     USER_ALREADY_EXIST("이미 가입되어 있는 유저입니다."),
-    TEST_ERROR_Message_("reason why error occured::optional")
+    TEST_ERROR_MESSAGE("reason why error occured::optional")
 }

--- a/src/main/kotlin/com/bside/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/bside/error/GlobalExceptionHandler.kt
@@ -1,0 +1,40 @@
+package com.bside.error
+
+import com.bside.common.type.ErrorMessage
+import com.bside.error.dto.ErrorResponseDto
+import com.bside.error.exception.BusinessException
+import com.bside.util.logger
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    private val logger by logger()
+
+    @ExceptionHandler(Exception::class)
+    fun handleAllException(e: Exception): ResponseEntity<ErrorResponseDto> {
+        logger.error(e.message, e)
+        return ErrorResponseDto.error(HttpStatus.INTERNAL_SERVER_ERROR, ErrorMessage.INTERNAL_SERVER_ERROR.name)
+    }
+
+    @ExceptionHandler(
+            BusinessException::class
+    )
+    fun handleBusinessException(e: BusinessException): ResponseEntity<ErrorResponseDto> {
+        logger.error(e.message, e)
+        return ErrorResponseDto.error(e.getHttpStatus(), e.message!!, e.getReason())
+    }
+
+    @ExceptionHandler(
+            MethodArgumentNotValidException::class
+    )
+    fun handleMethodArgumentNotValid(e: Exception): ResponseEntity<ErrorResponseDto>{
+        logger.error(e.message, e)
+        return ErrorResponseDto.error(HttpStatus.BAD_REQUEST, e.message!!)
+    }
+}
+

--- a/src/main/kotlin/com/bside/error/dto/ErrorResponseDto.kt
+++ b/src/main/kotlin/com/bside/error/dto/ErrorResponseDto.kt
@@ -1,0 +1,17 @@
+package com.bside.error.dto
+
+import io.swagger.annotations.ApiModelProperty
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+
+data class ErrorResponseDto(
+        val message: String,
+        val reason: String? = ""
+) {
+    companion object {
+        fun error(status: HttpStatus, message: String, reason: String? = ""): ResponseEntity<ErrorResponseDto> {
+            return ResponseEntity.status(status).body(ErrorResponseDto(message, reason))
+        }
+    }
+
+}

--- a/src/main/kotlin/com/bside/error/exception/AlreadyExistException.kt
+++ b/src/main/kotlin/com/bside/error/exception/AlreadyExistException.kt
@@ -1,0 +1,8 @@
+package com.bside.error.exception
+
+import org.springframework.http.HttpStatus
+
+class AlreadyExistException : BusinessException {
+    constructor(message: String) : super(HttpStatus.CONFLICT, message) {}
+    constructor(message: String, reason: String) : super(HttpStatus.CONFLICT, message, reason) {}
+}

--- a/src/main/kotlin/com/bside/error/exception/BusinessException.kt
+++ b/src/main/kotlin/com/bside/error/exception/BusinessException.kt
@@ -1,0 +1,16 @@
+package com.bside.error.exception
+
+import org.springframework.http.HttpStatus
+
+abstract class BusinessException : RuntimeException {
+    private var httpStatus: HttpStatus
+    private var reason: String = ""
+
+    constructor(httpStatus: HttpStatus, message: String, reason: String = "") : super(message) {
+        this.httpStatus = httpStatus
+        this.reason = reason
+    }
+
+    fun getHttpStatus() = this.httpStatus
+    fun getReason() = this.reason
+}

--- a/src/main/kotlin/com/bside/error/exception/TestCustomException.kt
+++ b/src/main/kotlin/com/bside/error/exception/TestCustomException.kt
@@ -1,0 +1,8 @@
+package com.bside.error.exception
+
+import org.springframework.http.HttpStatus
+
+class TestCustomException : BusinessException {
+    constructor(message: String) : super(HttpStatus.CONFLICT, message) {}
+    constructor(message: String, reason: String) : super(HttpStatus.CONFLICT, message, reason) {}
+}

--- a/src/main/kotlin/com/bside/service/AuthService.kt
+++ b/src/main/kotlin/com/bside/service/AuthService.kt
@@ -5,7 +5,9 @@ import com.bside.entity.Member
 import com.bside.config.jwt.TokenProvider
 import com.bside.repository.TokenRepository
 import com.bside.common.type.Authority
+import com.bside.common.type.ErrorMessage
 import com.bside.entity.RefreshToken
+import com.bside.error.exception.AlreadyExistException
 import com.bside.repository.MemberRepository
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -31,7 +33,7 @@ class AuthService(
 
     fun signup(memberRequestDto: MemberRequestDto) {
         if (memberRepository.existsByEmail(memberRequestDto.email)) {
-            throw RuntimeException("이미 가입되어 있는 유저입니다")
+            throw AlreadyExistException(ErrorMessage.USER_ALREADY_EXIST.name, ErrorMessage.USER_ALREADY_EXIST.reason)
         }
 
         memberRepository.save(


### PR DESCRIPTION
### 작업 내용
- ApiResponseDto 추가
- ErrorDto 추가 및 전역 에러 핸들링 구조 추가

### 에러처리 구조
- 비지니스 로직 예외클래스는 필요시 BusinessException 상속 받아 구현하도록 구조를 잡음
- 이외 예외는 GlobalExceptionHandler 를 통해잡고 필요하다면 추가해서 예외처리 가능하도록 했습니다.