### PR TITLE
도메인 entity, repository 세팅

### DIFF
--- a/src/main/kotlin/com/bside/activity/entity/Activity.kt
+++ b/src/main/kotlin/com/bside/activity/entity/Activity.kt
@@ -1,0 +1,37 @@
+package com.bside.activity.entity
+
+import com.bside.common.type.ActivityStatus
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+import org.springframework.data.mongodb.core.mapping.Field
+
+import java.time.LocalDateTime
+
+
+data class Location(
+        val lat: Double,
+        val lon: Double
+)
+
+@Document
+data class Activity(
+        @Id
+        @Field(name = "_id")
+        val id: ObjectId = ObjectId.get(),
+        val leaderId: ObjectId,
+        val crewId: ObjectId,
+        val memberIds: List<ObjectId> = listOf(),
+        val name: String,
+        val description: String,
+        val capacity: Int,
+        val joinCount:Int = 1,
+        val mainImage: String,
+        val location: Location,
+        val status: ActivityStatus = ActivityStatus.READY,
+        val startAt: LocalDateTime,
+        val createdDate: LocalDateTime = LocalDateTime.now(),
+        val modifiedDate: LocalDateTime = LocalDateTime.now()
+)
+

--- a/src/main/kotlin/com/bside/activity/reposittory/ActivityRepository.kt
+++ b/src/main/kotlin/com/bside/activity/reposittory/ActivityRepository.kt
@@ -1,0 +1,8 @@
+package com.bside.activity.reposittory
+
+import com.bside.activity.entity.Activity
+
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface ActivityRepository: MongoRepository<Activity, String>{
+}

--- a/src/main/kotlin/com/bside/common/type/ActivityStatus.kt
+++ b/src/main/kotlin/com/bside/common/type/ActivityStatus.kt
@@ -1,0 +1,5 @@
+package com.bside.common.type
+
+enum class ActivityStatus {
+    READY, RUNNING, FINISHED
+}

--- a/src/main/kotlin/com/bside/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/bside/config/SwaggerConfig.kt
@@ -3,6 +3,7 @@ package com.bside.config
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+
 import springfox.documentation.builders.ApiInfoBuilder
 import springfox.documentation.builders.PathSelectors
 import springfox.documentation.builders.RequestHandlerSelectors
@@ -10,8 +11,9 @@ import springfox.documentation.service.*
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spi.service.contexts.SecurityContext
 import springfox.documentation.spring.web.plugins.Docket
-import java.util.*
 
+import java.util.function.Predicate
+import java.util.*
 
 @Profile("local || dev")
 @Configuration
@@ -21,13 +23,15 @@ class SwaggerConfig {
     fun api(): Docket? {
         //Docket: Swagger 설정의 핵심이 되는 Bean
         return Docket(DocumentationType.OAS_30)
-            .securityContexts(listOf(securityContext()))
-            .securitySchemes(listOf(apiKey()) as List<SecurityScheme>?)
-            .select()
-            .apis(RequestHandlerSelectors.basePackage("com.bside.controller")) // controller package 지정
-            .paths(PathSelectors.any())
-            .build()
-            .apiInfo(apiInfo()) //:Swagger UI 로 노출할 정보
+                .securityContexts(listOf(securityContext()))
+                .securitySchemes(listOf(apiKey()) as List<SecurityScheme>?)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.ant("/api/**")
+                        .and(Predicate.not(
+                                PathSelectors.regex("/api/error.*"))))
+                .build()
+                .apiInfo(apiInfo()) //:Swagger UI 로 노출할 정보
     }
 
     // api 정보 등록

--- a/src/main/kotlin/com/bside/crew/entity/Crew.kt
+++ b/src/main/kotlin/com/bside/crew/entity/Crew.kt
@@ -1,0 +1,28 @@
+package com.bside.crew.entity
+
+import org.bson.types.ObjectId
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+import org.springframework.data.mongodb.core.mapping.Field
+
+import java.time.LocalDateTime
+
+// 가입 인삿말 필드 추가 필요.
+@Document
+data class Crew(
+        @Id
+        @Field(name = "_id")
+        val id: ObjectId = ObjectId.get(),
+        val leaderId: ObjectId,
+        val memberIds: List<ObjectId> = listOf(),
+        val name: String,
+        val title: String,
+        val description: String,
+        val capacity: Int,
+        val joinCount:Int = 1,
+        val mainImage: String,
+        val location: Map<String, List<String>>,
+        val createdDate: LocalDateTime = LocalDateTime.now(),
+        val modifiedDate: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/com/bside/crew/reposittory/CrewRepository.kt
+++ b/src/main/kotlin/com/bside/crew/reposittory/CrewRepository.kt
@@ -1,0 +1,8 @@
+package com.bside.crew.reposittory
+
+import com.bside.crew.entity.Crew
+
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface CrewRepository: MongoRepository<Crew, String>{
+}

--- a/src/main/kotlin/com/bside/feedImage/entity/FeedImage.kt
+++ b/src/main/kotlin/com/bside/feedImage/entity/FeedImage.kt
@@ -1,0 +1,16 @@
+package com.bside.feedImage.entity
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+import org.springframework.data.mongodb.core.mapping.Field
+
+@Document
+data class FeedImage(
+        @Id
+        @Field("_id")
+        val id: ObjectId = ObjectId.get(),
+        val memberId: ObjectId,
+        val crewId: ObjectId,
+        val image: String
+)

--- a/src/main/kotlin/com/bside/feedImage/repository/FeedImageRepository.kt
+++ b/src/main/kotlin/com/bside/feedImage/repository/FeedImageRepository.kt
@@ -1,0 +1,8 @@
+package com.bside.feedImage.repository
+
+import com.bside.feedImage.entity.FeedImage
+
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface FeedImageRepository: MongoRepository<FeedImage, String> {
+}

--- a/src/main/kotlin/com/bside/member/MemberController.kt
+++ b/src/main/kotlin/com/bside/member/MemberController.kt
@@ -24,15 +24,4 @@ class MemberController(
     fun getEmail(@RequestParam email: String): MemberResponseDto {
         return memberService.getMemberInfo(email)
     }
-
-    // 슬랙 에러알람 확인을 위한 테스트 용도 입니다. 다음 개발시 삭제 예정입니다.
-    @GetMapping("/error")
-    fun makeError() {
-        try {
-            val v = 1 / 0
-        } catch (e: Exception) {
-            logger.error("error occurred", e)
-        }
-    }
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,5 @@
 ###############################
 server:
   port: 8080
+  servlet:
+    contextPath: /api


### PR DESCRIPTION
**도메인 entity, repository 세팅**
- 도메인 entity 는 일단 기획이 구체화되면서 변경사항이 필요할 수도 있는데 이부분은 각자 작업자가 수정하면서 진행하면 될 것 같습니다. 

**스웨거 설정 변경.** 
- 컨트롤러 전역 api prefix 추가
- 이제 도메인 별로 폴더 구조를 변경하였기 때문에 특정 package 로 스웨거 api 노출을 설정할 수 없기때문에 paths 설정에서 /api/** 으로 스웨거 api 노출을 지정하였습니다. 
- 스웨거에서 디폴트로 노출시키는 의미없는 error 컨트롤러 api 노출을 제외하기 위해서  paths 설정에서  "/api/error.*" 부분을 추가했습니다.

**ISSUE**
- https://github.com/bsideproject/11-02-backend/issues/35